### PR TITLE
disable compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,4 +146,6 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+#IDE files
+.idea
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ You can specify additional search domains.
 sudo snap set easy-openvpn-server additional-search-domains="test"
 ```
 
+You can specify compression (disabled by default)
+```bash
+sudo snap set easy-openvpn-server compress="lzo" 
+```
+
+
 ## FAQ
 
 ### Why OpenVPN instead of Wireguard?

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -58,6 +58,10 @@ description: |
   You can specify additional search domains.
 
   `sudo snap set easy-openvpn-server additional-search-domains="test"`
+  
+  You can specify compression (disabled by default)
+  
+  `sudo snap set easy-openvpn-server compression="lzo"`
 
 license: Apache-2.0
 
@@ -110,7 +114,7 @@ apps:
   easy-openvpn-server:
     command: bin/setup.py
     plugs:
-      - network    
+      - network
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
@@ -122,7 +126,7 @@ hooks:
       - network-control
   connect-plug-network-control: {}
   connect-plug-firewall-control: {}
-  
+
 
 parts:
   openvpn:
@@ -140,7 +144,7 @@ parts:
     plugin: python
     source: easy-openvpn-server
     requirements:
-      - requirements.txt 
+      - requirements.txt
     stage-packages:
       # Dependencies for `cryptography` on non-amd64 systems.
       - libffi7

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -61,7 +61,7 @@ description: |
   
   You can specify compression (disabled by default)
   
-  `sudo snap set easy-openvpn-server compression="lzo"`
+  `sudo snap set easy-openvpn-server compress="lzo"`
 
 license: Apache-2.0
 

--- a/templates/client.ovpn
+++ b/templates/client.ovpn
@@ -18,7 +18,10 @@ server-poll-timeout 5
 # with OpenVPN versions <2.4.
 # Note: `comp-lzo` option is superseded by `compress lzo`, but the later is
 # not yet supported by networkmanager. https://gitlab.gnome.org/GNOME/NetworkManager-openvpn/issues/1
-comp-lzo
+#comp-lzo
+# now compress is handled correctly. https://gitlab.gnome.org/GNOME/NetworkManager-openvpn/-/merge_requests/4
+compress {{compress}}
+
 # tun has lower traffic overhead than tap.
 dev tun
 
@@ -48,7 +51,7 @@ mute-replay-warnings
 <cert>
 {{cert -}}
 </cert>
-# Client private key 
+# Client private key
 <key>
 {{key -}}
 </key>

--- a/templates/server.conf
+++ b/templates/server.conf
@@ -73,7 +73,11 @@ auth SHA256
 
 # Compress packets with lzo. lz4 is more efficient, but it's not compatible
 # with OpenVPN versions <2.4.
-compress lzo
+# Disable by default to avoid Compression oracle attacks,
+# see: https://superuser.com/questions/1686651/why-is-compression-not-recommended-in-openvpn
+#
+compress no
+
 # tun has lower traffic overhead than tap.
 dev tun
 keepalive 10 60

--- a/templates/server.conf
+++ b/templates/server.conf
@@ -76,7 +76,7 @@ auth SHA256
 # Disable by default to avoid Compression oracle attacks,
 # see: https://superuser.com/questions/1686651/why-is-compression-not-recommended-in-openvpn
 #
-compress no
+compress {{compress}}
 
 # tun has lower traffic overhead than tap.
 dev tun


### PR DESCRIPTION
Disable by default to avoid Compression oracle attacks
- why?, see: https://superuser.com/questions/1686651/why-is-compression-not-recommended-in-openvpn
- add ability to set compression value from command line
- update snapcraft/readme files to show/explain new command line feature
- https://github.com/IBCNServices/easy-openvpn-server/issues/15

Note: this also includes mauerr upgrade to core20 https://github.com/IBCNServices/easy-openvpn-server/pull/24/commits/e9720a830d8ae9f913fd8d139830169b5947cb18