### PR TITLE
Remove compression but support existing client configs with compression enabled.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -81,7 +81,7 @@ apps:
     plugs:
       - network
       - network-bind
-      - network-observe
+#      - network-control
 #      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
@@ -93,7 +93,7 @@ apps:
     plugs:
       - network
       - network-bind
-      - network-observe
+#      - network-control
 #      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
@@ -106,7 +106,7 @@ apps:
     plugs:
       - network
       - network-bind
-      - network-observe
+#      - network-control
 #      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
@@ -122,7 +122,7 @@ hooks:
   configure:
     plugs:
       - network
-      - network-observe
+#      - network-control
 #  connect-plug-network-control: {}
 #  connect-plug-firewall-control: {}
   

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -81,8 +81,8 @@ apps:
     plugs:
       - network
       - network-bind
-#      - network-control
-#      - firewall-control
+      - network-control
+      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
   udp-server:
@@ -93,8 +93,8 @@ apps:
     plugs:
       - network
       - network-bind
-#      - network-control
-#      - firewall-control
+      - network-control
+      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
   status:
@@ -106,8 +106,8 @@ apps:
     plugs:
       - network
       - network-bind
-#      - network-control
-#      - firewall-control
+      - network-control
+      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
   easy-openvpn-server:
@@ -122,9 +122,9 @@ hooks:
   configure:
     plugs:
       - network
-#      - network-control
-#  connect-plug-network-control: {}
-#  connect-plug-firewall-control: {}
+      - network-control
+  connect-plug-network-control: {}
+  connect-plug-firewall-control: {}
   
 
 parts:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -81,7 +81,7 @@ apps:
     plugs:
       - network
       - network-bind
-#      - network-control
+      - network-observe
 #      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
@@ -93,7 +93,7 @@ apps:
     plugs:
       - network
       - network-bind
-#      - network-control
+      - network-observe
 #      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
@@ -106,7 +106,7 @@ apps:
     plugs:
       - network
       - network-bind
-#      - network-control
+      - network-observe
 #      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
@@ -122,7 +122,7 @@ hooks:
   configure:
     plugs:
       - network
-#      - network-control
+      - network-observe
 #  connect-plug-network-control: {}
 #  connect-plug-firewall-control: {}
   

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -81,8 +81,8 @@ apps:
     plugs:
       - network
       - network-bind
-      - network-control
-      - firewall-control
+#      - network-control
+#      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
   udp-server:
@@ -93,8 +93,8 @@ apps:
     plugs:
       - network
       - network-bind
-      - network-control
-      - firewall-control
+#      - network-control
+#      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
   status:
@@ -106,8 +106,8 @@ apps:
     plugs:
       - network
       - network-bind
-      - network-control
-      - firewall-control
+#      - network-control
+#      - firewall-control
     environment:
       LD_PRELOAD: "$SNAP/wraplib.so"
   easy-openvpn-server:
@@ -122,9 +122,9 @@ hooks:
   configure:
     plugs:
       - network
-      - network-control
-  connect-plug-network-control: {}
-  connect-plug-firewall-control: {}
+#      - network-control
+#  connect-plug-network-control: {}
+#  connect-plug-firewall-control: {}
   
 
 parts:

--- a/templates/client.ovpn
+++ b/templates/client.ovpn
@@ -14,11 +14,8 @@ client
 # If the server doesn't answer after 5 seconds, try the next server.
 server-poll-timeout 5
 
-# Compress packets with lzo. lz4 is more efficient, but it's not compatible
-# with OpenVPN versions <2.4.
-# Note: `comp-lzo` option is superseded by `compress lzo`, but the later is
-# not yet supported by networkmanager. https://gitlab.gnome.org/GNOME/NetworkManager-openvpn/issues/1
-comp-lzo
+# Disable compression for new clients and use Data Channel Offload.
+# comp-lzo
 # tun has lower traffic overhead than tap.
 dev tun
 

--- a/templates/client.ovpn
+++ b/templates/client.ovpn
@@ -14,8 +14,9 @@ client
 # If the server doesn't answer after 5 seconds, try the next server.
 server-poll-timeout 5
 
-# Disable compression for new clients and use Data Channel Offload.
-# comp-lzo
+# Disable compression for new clients and use Data Channel Offload. 
+# Compression is insecure and should not be used.
+
 # tun has lower traffic overhead than tap.
 dev tun
 

--- a/templates/server.conf
+++ b/templates/server.conf
@@ -71,9 +71,9 @@ ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM
 # be ignored when GCM is used (which uses SHA384)
 auth SHA256
 
-# Compress packets with lzo. lz4 is more efficient, but it's not compatible
-# with OpenVPN versions <2.4.
-compress lzo
+# Allow for asymmetric compression to support older client config files.
+# Newly produced client config will not use compression.
+allow-compression asym
 # tun has lower traffic overhead than tap.
 dev tun
 keepalive 10 60


### PR DESCRIPTION
Basically stole the thought processes from #24 but applied them without the option for customization based on the deprecation of compression by OpenVPN.